### PR TITLE
Fix NewsletterSubscriber date_subscribed

### DIFF
--- a/pennyblack/module/subscriber/models.py
+++ b/pennyblack/module/subscriber/models.py
@@ -5,7 +5,12 @@ from django.db import models
 from pennyblack import settings
 from pennyblack.options import NewsletterReceiverMixin, JobUnitMixin, JobUnitAdmin
 
-from django.utils.timezone import now
+try:
+    from django.utils.timezone import now
+except ImportError:
+    from datetime import datetime
+    now = datetime.now
+
 
 
 class NewsletterSubscriberManager(models.Manager):


### PR DESCRIPTION
This fixes issue #43:

The `NewsletterSubscriber.date_subscribed` default is `datetime.datetime.now()`, which has two problems:
1. The time is fixed when the module is loaded (it's the same for every added subscriber during one run of a script, or until the webserver is reloaded)
2. The date/time is not timezone-aware, causing warnings when timezones are enabled in Django 1.4 and newer
