### PR TITLE
Update path to default django 1.8.

### DIFF
--- a/pennyblack/models/newsletter.py
+++ b/pennyblack/models/newsletter.py
@@ -1,7 +1,7 @@
 # coding=utf-8
 import exceptions
 
-from django.conf.urls.defaults import patterns, url
+from django.conf.urls import patterns, url
 from django.core.exceptions import ImproperlyConfigured
 from django.contrib import admin
 from django.contrib.contenttypes.models import ContentType


### PR DESCRIPTION
django.conf.urls.defaults was renamed to django.conf.urls. Update to make it works with newer Django version (1.8+)
